### PR TITLE
added a section on basic math operations

### DIFF
--- a/pages/intro/python.tex
+++ b/pages/intro/python.tex
@@ -73,6 +73,33 @@ Exit IPython by typing \code{exit()} or \code{quit()} (or typing CTRL-D).
 
 \subsection{Python by Example}
 
+\subsubsection{Basic Math Operations}
+
+Python supports all basic arithmetic operations, including exponenation. For example, the following code:
+\begin{python}
+print 3 + 5
+print 3 - 5
+print 3 * 5
+print 3 / 5
+print 3 ** 5
+\end{python}
+
+\noindent will produce the following output:
+\begin{python}
+8
+-2
+15
+0
+243
+\end{python}
+
+Notice that division is always considered as integer division, hence the result being 0 on the example above. To force a floating point division you can force one of the operands to be a floating point number:
+\begin{python}
+print 3 / 5.0
+0.6
+\end{python}
+
+Also, notice that the symbol \texttt{**} is used as exponentation operator, unlike other major languages which use the symbol \texttt{\^}. In fact, the \texttt{\^} symbol has a different meaning in Python (bitwise XOR) so, in the beginning, be sure to double-check your code if it uses exponentiation and it is giving unexpected results.
 
 \subsubsection{Data Structures}
 


### PR DESCRIPTION
Added a section on basic math operations. Exponentiation is used later in the guide (section 0.2.4) but it is never introduced as being the '**' operator. From my (short) experience, people from non-Python backgrounds usually try to use the '^' operator for exponentiation. This is not only wrong but it is actually the XOR operator in Python, which means it gives unexpected results and adds to the confusion. This section would also be a nice place to explain that '/' means integer division in Python.