### PR TITLE
Small day0 changes

### DIFF
--- a/pages/intro/no.tex
+++ b/pages/intro/no.tex
@@ -24,7 +24,7 @@ One important property of a function $f(x)$ is whether it is a \textbf{convex fu
  \end{figure}
 
 
-Intuitively, imagine dropping a ball on either side of Figure \ref{fig:convexfn}, the ball will role to the bottom of the bowl independently from where it is dropped. This is the main benefit of a convex function. On the other hand, if you drop a ball from the left side of Figure \ref{fig:nonconvexfn} it will reach a different position than if you drop a ball from its right side. Moreover, dropping it from the left side will lead you to a much better (\emph{i.e.}, lower) place than if you drop the ball from the right side. This is the main problem with non-convex functions: there are no guarantees about the quality of the local minimum you find.
+Intuitively, imagine dropping a ball on either side of Figure \ref{fig:convexfn}, the ball will roll to the bottom of the bowl independently from where it is dropped. This is the main benefit of a convex function. On the other hand, if you drop a ball from the left side of Figure \ref{fig:nonconvexfn} it will reach a different position than if you drop a ball from its right side. Moreover, dropping it from the left side will lead you to a much better (\emph{i.e.}, lower) place than if you drop the ball from the right side. This is the main problem with non-convex functions: there are no guarantees about the quality of the local minimum you find.
 
 More formally, some concepts to understand about convex functions are:
 

--- a/pages/intro/no.tex
+++ b/pages/intro/no.tex
@@ -211,9 +211,9 @@ def gradient_descent(start_x,func,grad):
     for i in xrange(max_iter):
         x_old = x_new
         #Use beta egual to -1 for gradient descent 
-        x_new = x_old - step_size * get_grad(x_new)
-        f_x_new = get_y(x_new)
-        f_x_old = get_y(x_old)
+        x_new = x_old - step_size * grad(x_new)
+        f_x_new = func(x_new)
+        f_x_old = func(x_old)
         res.append([x_new,f_x_new])
         if(abs(f_x_new - f_x_old) < prec):
             print "change in function values too small, leaving"

--- a/pages/intro/python.tex
+++ b/pages/intro/python.tex
@@ -339,7 +339,7 @@ Handling of exceptions is made with the \textit{try} statement:
 \begin{python}
 while True:
     try:
-        x = int(raw_input("Please enter a number: ")
+        x = int(raw_input("Please enter a number: "))
         break
     except ValueError:
         print "Oops! That was no valid number. Try again..."


### PR DESCRIPTION
- missing a ')' in intro/python.tex:342
- "the ball will role" -> "the ball will roll" (in intro/no.tex:27)
- gradient_descent (as presented in intro/no.tex:202) should use the given cost/gradient function instead of the globally defined get_y and grad functions -- this should also be corrected in lxmls-toolkit