### PR TITLE
Small typos

### DIFF
--- a/pages/parsing/parsing.tex
+++ b/pages/parsing/parsing.tex
@@ -449,7 +449,7 @@ the partition function and the posterior marginals.
 	\STATE
 	\STATE \COMMENT{Induction}
 	\FOR[$k$ is length of span]{$k=1$ {\bfseries to} $N$} 
-	\FOR[$s$ is start of span]{$s=1$ {\bfseries to} $N-k$}
+	\FOR[$s$ is start of span]{$s=0$ {\bfseries to} $N-k$}
 	\STATE Set $t := s + k$ \COMMENT{$t$ is end of span}
 	\STATE
 	\STATE \COMMENT{First, create incomplete spans.}
@@ -457,8 +457,8 @@ the partition function and the posterior marginals.
 	\STATE $\mathrm{incomplete}[s,t,\rightarrow] := \max_{s \le r < t} (\mathrm{complete}[s][r][\rightarrow] + \mathrm{complete}[r+1][t][\leftarrow] + s_{\boldsymbol{\theta}}(s,t))$
 	\STATE
 	\STATE \COMMENT{Then, create complete spans.}
-	\STATE $\mathrm{complete}[s,t,\leftarrow] := \max_{s \le r < t} (\mathrm{complete}[s][r][\leftarrow] + \mathrm{incomplete}[r][t][\leftarrow]$
-	\STATE $\mathrm{complete}[s,t,\rightarrow] := \max_{s < r \le t} (\mathrm{incomplete}[s][r][\rightarrow] + \mathrm{complete}[r][t][\rightarrow])$
+	\STATE $\mathrm{complete}[s,t,\leftarrow] := \max_{s \le r < t} (\mathrm{complete}[s][r][\leftarrow] + \mathrm{incomplete}[r][t][\leftarrow]$)
+	\STATE $\mathrm{complete}[s,t,\rightarrow] := \max_{s \le r < t} (\mathrm{incomplete}[s][r+1][\rightarrow] + \mathrm{complete}[r+1][t][\rightarrow])$
 	\ENDFOR
 	\ENDFOR
 	\STATE

--- a/pages/parsing/parsing.tex
+++ b/pages/parsing/parsing.tex
@@ -457,7 +457,7 @@ the partition function and the posterior marginals.
 	\STATE $\mathrm{incomplete}[s,t,\rightarrow] := \max_{s \le r < t} (\mathrm{complete}[s][r][\rightarrow] + \mathrm{complete}[r+1][t][\leftarrow] + s_{\boldsymbol{\theta}}(s,t))$
 	\STATE
 	\STATE \COMMENT{Then, create complete spans.}
-	\STATE $\mathrm{complete}[s,t,\leftarrow] := \max_{s \le r < t} (\mathrm{complete}[s][r][\leftarrow] + \mathrm{incomplete}[r][t][\leftarrow]$)
+	\STATE $\mathrm{complete}[s,t,\leftarrow] := \max_{s \le r < t} (\mathrm{complete}[s][r][\leftarrow] + \mathrm{incomplete}[r][t][\leftarrow])$
 	\STATE $\mathrm{complete}[s,t,\rightarrow] := \max_{s \le r < t} (\mathrm{incomplete}[s][r+1][\rightarrow] + \mathrm{complete}[r+1][t][\rightarrow])$
 	\ENDFOR
 	\ENDFOR

--- a/pages/parsing/parsing.tex
+++ b/pages/parsing/parsing.tex
@@ -561,7 +561,7 @@ Observe the statistics which are shown. How many features are there in total?
 \item We will now have a close look on the \emph{features} that can be used in the parser. 
 Examine the file:
 \begin{quote}
-{\tt code/parsing/dependency\_features.py}. 
+{\tt lxmls/parsing/dependency\_features.py}. 
 \end{quote}
 The following method takes a sentence and computes a vector of features for each possible arc $\langle h, m \rangle$: 
 \begin{python}

--- a/pages/sequences/pos.tex
+++ b/pages/sequences/pos.tex
@@ -54,13 +54,13 @@ both the train and test set, using the methods in class HMM:
 >>> posterior_pred_train = hmm.posterior_decode_corpus(train_seq)
 >>> eval_viterbi_train =   hmm.evaluate_corpus(train_seq, viterbi_pred_train)
 >>> eval_posterior_train =  hmm.evaluate_corpus(train_seq, posterior_pred_train)
->>> print "Train Set Accuracy: Posterior Decode \%.3f, Viterbi Decode: \%.3f"\%(eval_posterior_train,eval_viterbi_train)
+>>> print "Train Set Accuracy: Posterior Decode %.3f, Viterbi Decode: %.3f"%(eval_posterior_train,eval_viterbi_train)
 Train Set Accuracy: Posterior Decode 0.985, Viterbi Decode: 0.985
 >>> viterbi_pred_test = hmm.viterbi_decode_corpus(test_seq)
 >>> posterior_pred_test = hmm.posterior_decode_corpus(test_seq)
 >>> eval_viterbi_test =   hmm.evaluate_corpus(test_seq,viterbi_pred_test)
 >>> eval_posterior_test = hmm.evaluate_corpus(test_seq,posterior_pred_test)
->>> print "Test Set Accuracy: Posterior Decode \%.3f, Viterbi Decode: \%.3f"\%(eval_posterior_test,eval_viterbi_test)
+>>> print "Test Set Accuracy: Posterior Decode %.3f, Viterbi Decode: %.3f"%(eval_posterior_test,eval_viterbi_test)
 Test Set Accuracy: Posterior Decode 0.350, Viterbi Decode: 0.509
 \end{python}
 What do you observe? Remake the previous exercise but now train the HMM
@@ -84,7 +84,7 @@ Smoothing 0.000000 -- Test Set Accuracy: Posterior Decode 0.370, Viterbi Decode:
 >>> posterior_pred_test = hmm.posterior_decode_corpus(test_seq)
 >>> eval_viterbi_test =   hmm.evaluate_corpus(test_seq, viterbi_pred_test)
 >>> eval_posterior_test = hmm.evaluate_corpus(test_seq, posterior_pred_test)
->>> print "Best Smoothing \%f --  Test Set Accuracy: Posterior Decode \%.3f, Viterbi Decode: \%.3f"%(best_smoothing,eval_posterior_test,eval_viterbi_test)
+>>> print "Best Smoothing %f --  Test Set Accuracy: Posterior Decode %.3f, Viterbi Decode: %.3f"%(best_smoothing,eval_posterior_test,eval_viterbi_test)
 Best Smoothing 0.100000 --  Test Set Accuracy: Posterior Decode 0.837, Viterbi Decode: 0.827
 \end{python}
 


### PR DESCRIPTION
- Last year at the summer school I had some trouble with the Eisner algorithm, and I left with the impression that the pseudo-code was a bit off. Today I spent some time on this and found that the variable s should start at 0. On the right complete span, I also used s <= r < t, and then r+1, instead of having s < r <= t and then r, since all the other spans use s <= r < t -- I believe this makes it more legible.

- Fixed a couple of other small typos