### PR TITLE
removed '>>>' from all python environments in day2

### DIFF
--- a/pages/sequences/decoding.tex
+++ b/pages/sequences/decoding.tex
@@ -171,10 +171,13 @@ Use the given function \emph{compute\_scores} on the first training sequence and
 %then you are ready to go).
 
 \begin{python}
->>> initial_scores, transition_scores, final_scores, emission_scores = hmm.compute_scores(simple.train.seq_list[0])
->>> print initial_scores
+initial_scores, transition_scores, final_scores, emission_scores = hmm.compute_scores(simple.train.seq_list[0])
+print initial_scores
+
 [-0.40546511 -1.09861229]
->>> print transition_scores
+
+print transition_scores
+
 [[[-0.69314718        -inf]
   [-0.69314718 -0.47000363]]
 
@@ -183,9 +186,13 @@ Use the given function \emph{compute\_scores} on the first training sequence and
 
  [[-0.69314718        -inf]
   [-0.69314718 -0.47000363]]]
->>> print final_scores
+
+print final_scores
+
 [       -inf -0.98082925]
->>> print emission_scores
+
+print emission_scores
+
 [[-0.28768207 -1.38629436]
  [-0.28768207 -1.38629436]
  [-1.38629436 -0.98082925]
@@ -233,24 +240,31 @@ This will be used later in our decoding algorithms.
 To observe why this is important, type the 
 following:
 \begin{python}
->>> import numpy as np
->>> a = np.random.rand(10)
->>> np.log(sum(np.exp(a)))
+import numpy as np
+a = np.random.rand(10)
+np.log(sum(np.exp(a)))
 2.8397172643228661
->>> np.log(sum(np.exp(10*a)))
+
+np.log(sum(np.exp(10*a)))
 10.121099917705818
->>> np.log(sum(np.exp(100*a)))
+
+np.log(sum(np.exp(100*a)))
 93.159220940569128
->>> np.log(sum(np.exp(1000*a)))
+
+np.log(sum(np.exp(1000*a)))
 inf
->>> from lxmls.sequences.log_domain import *
->>> logsum(a)
+
+from lxmls.sequences.log_domain import *
+logsum(a)
 2.8397172643228665
->>> logsum(10*a)
+
+logsum(10*a)
 10.121099917705818
->>> logsum(100*a)
+
+logsum(100*a)
 93.159220940569114
->>> logsum(1000*a)
+
+logsum(1000*a)
 925.88496219586864
 \end{python}
 \end{exercise}
@@ -475,11 +489,14 @@ passes give the same log-likelihood.
 %Use the provided function that makes use of Equation \ref{eq::fbsanity} to make
 %sure your implementation is correct: 
 \begin{python}
->>> log_likelihood, forward = hmm.decoder.run_forward(initial_scores, transition_scores, final_scores, emission_scores)
->>> print 'Log-Likelihood =', log_likelihood
+log_likelihood, forward = hmm.decoder.run_forward(initial_scores, transition_scores, final_scores, emission_scores)
+print 'Log-Likelihood =', log_likelihood
+
 Log-Likelihood = -5.06823232601
->>> log_likelihood, backward = hmm.decoder.run_backward(initial_scores, transition_scores, final_scores, emission_scores)
->>> print 'Log-Likelihood =', log_likelihood
+
+log_likelihood, backward = hmm.decoder.run_backward(initial_scores, transition_scores, final_scores, emission_scores)
+print 'Log-Likelihood =', log_likelihood
+
 Log-Likelihood = -5.06823232601
 \end{python}
 \end{exercise}
@@ -578,12 +595,13 @@ the output. Note that the state posteriors are a proper
 probability distribution (the lines of the result sum to 1).
 
 \begin{python}
->>> initial_scores, transition_scores, final_scores, emission_scores = hmm.compute_scores(simple.train.seq_list[0])
->>> state_posteriors, _, _ = hmm.compute_posteriors(initial_scores,
-                                                    transition_scores,
-                                                    final_scores,
-                                                    emission_scores)
->>> print state_posteriors
+initial_scores, transition_scores, final_scores, emission_scores = hmm.compute_scores(simple.train.seq_list[0])
+state_posteriors, _, _ = hmm.compute_posteriors(initial_scores,
+                                                transition_scores,
+                                                final_scores,
+                                                emission_scores)
+print state_posteriors
+
 [[ 0.95738152  0.04261848]
  [ 0.75281282  0.24718718]
  [ 0.26184794  0.73815206]
@@ -594,19 +612,25 @@ probability distribution (the lines of the result sum to 1).
 \begin{exercise}
 Run the posterior decode on the first test sequence, and evaluate it.
 \begin{python}
->>> y_pred = hmm.posterior_decode(simple.test.seq_list[0])
->>> print "Prediction test 0:", y_pred
+y_pred = hmm.posterior_decode(simple.test.seq_list[0])
+print "Prediction test 0:", y_pred
+
 walk/rainy walk/rainy shop/sunny clean/sunny
->>> print "Truth test 0:", simple.test.seq_list[0]
+
+print "Truth test 0:", simple.test.seq_list[0]
+
 walk/rainy walk/sunny shop/sunny clean/sunny 
 \end{python}
 
 Do the same for the second test sequence:
 \begin{python}
->>> y_pred = hmm.posterior_decode(simple.test.seq_list[1])
->>> print "Prediction test 1:", y_pred
+y_pred = hmm.posterior_decode(simple.test.seq_list[1])
+print "Prediction test 1:", y_pred
+
 clean/rainy walk/rainy tennis/rainy walk/rainy 
->>> print "Truth test 1:", simple.test.seq_list[1]
+
+print "Truth test 1:", simple.test.seq_list[1]
+
 clean/sunny walk/sunny tennis/sunny walk/sunny 
 \end{python}
 
@@ -625,16 +649,23 @@ def train_supervised(self,sequence_list, smoothing):
 
 Try, for example, adding 0.1 to all the counts, and repeating this exercise with that smoothing. What do you observe?
 \begin{python}
->>> hmm.train_supervised(simple.train, smoothing=0.1)
->>> y_pred = hmm.posterior_decode(simple.test.seq_list[0])
->>> print "Prediction test 0 with smoothing:", y_pred
+hmm.train_supervised(simple.train, smoothing=0.1)
+y_pred = hmm.posterior_decode(simple.test.seq_list[0])
+print "Prediction test 0 with smoothing:", y_pred
+
 walk/rainy walk/rainy shop/sunny clean/sunny 
->>> print "Truth test 0:", simple.test.seq_list[0]
+
+print "Truth test 0:", simple.test.seq_list[0]
+
 walk/rainy walk/sunny shop/sunny clean/sunny
->>> y_pred = hmm.posterior_decode(simple.test.seq_list[1])
->>> print "Prediction test 1 with smoothing:", y_pred
+
+y_pred = hmm.posterior_decode(simple.test.seq_list[1])
+print "Prediction test 1 with smoothing:", y_pred
+
 clean/sunny walk/sunny tennis/sunny walk/sunny 
->>> print "Truth test 1:", simple.test.seq_list[1]
+
+print "Truth test 1:", simple.test.seq_list[1]
+
 clean/sunny walk/sunny tennis/sunny walk/sunny 
 \end{python}
 \end{exercise}
@@ -801,17 +832,23 @@ in the module {\tt sequence\_classifier.py}.
 Test your method on both test sequences and compare the results with
 the ones given.
 \begin{python}
->>> hmm.train_supervised(simple.train, smoothing=0.1)
->>> y_pred, score = hmm.viterbi_decode(simple.test.seq_list[0])
->>> print "Viterbi decoding Prediction test 0 with smoothing:", y_pred, score
+hmm.train_supervised(simple.train, smoothing=0.1)
+y_pred, score = hmm.viterbi_decode(simple.test.seq_list[0])
+print "Viterbi decoding Prediction test 0 with smoothing:", y_pred, score
+
 walk/rainy walk/rainy shop/sunny clean/sunny  -6.02050124698
->>> print "Truth test 0:", simple.test.seq_list[0]
+
+print "Truth test 0:", simple.test.seq_list[0]
+
 walk/rainy walk/sunny shop/sunny clean/sunny 
->>> y_pred, score = hmm.viterbi_decode(simple.test.seq_list[1])
->>> print "Viterbi decoding Prediction test 1 with 
-smoothing:", y_pred, score
+
+y_pred, score = hmm.viterbi_decode(simple.test.seq_list[1])
+print "Viterbi decoding Prediction test 1 with smoothing:", y_pred, score
+
 clean/sunny walk/sunny tennis/sunny walk/sunny  -11.713974074
->>> print "Truth test 1:", simple.test.seq_list[1]
+
+print "Truth test 1:", simple.test.seq_list[1]
+
 clean/sunny walk/sunny tennis/sunny walk/sunny 
 \end{python}
 

--- a/pages/sequences/hmm.tex
+++ b/pages/sequences/hmm.tex
@@ -108,27 +108,35 @@ Load the simple sequence dataset.
 From the ipython command line create a simple sequence object and look
 at the training and test set.
 \begin{python}
->>> import lxmls.readers.simple_sequence as ssr
->>> simple = ssr.SimpleSequence()
->>> print simple.train
+import lxmls.readers.simple_sequence as ssr
+simple = ssr.SimpleSequence()
+print simple.train
+
 [walk/rainy walk/sunny shop/sunny clean/sunny , walk/rainy walk/rainy shop/rainy clean/sunny , walk/sunny shop/sunny shop/sunny clean/sunny ]
->>> print simple.test
+
+print simple.test
+
 [walk/rainy walk/sunny shop/sunny clean/sunny , clean/sunny walk/sunny tennis/sunny walk/sunny ]
 \end{python}
 Get in touch with the classes used to store the sequences, you will need this for the next exercise. Note that each label is internally stored as a number. This number can be used as index of an array to store information regarding that label.
 \begin{python}
->>> for sequence in simple.train.seq_list:
-	print sequence
+for sequence in simple.train.seq_list:
+    print sequence
+
 walk/rainy walk/sunny shop/sunny clean/sunny
 walk/rainy walk/rainy shop/rainy clean/sunny
 walk/sunny shop/sunny shop/sunny clean/sunny
->>> for sequence in simple.train.seq_list:
-	print sequence.x
+
+for sequence in simple.train.seq_list:
+    print sequence.x
+
 [0, 0, 1, 2]
 [0, 0, 1, 2]
 [0, 1, 1, 2]
->>> for sequence in simple.train.seq_list:
-	print sequence.y
+
+for sequence in simple.train.seq_list:
+    print sequence.y
+
 [0, 1, 1, 1]
 [0, 0, 0, 1]
 [1, 1, 1, 1]

--- a/pages/sequences/ml.tex
+++ b/pages/sequences/ml.tex
@@ -157,17 +157,24 @@ The provided function \emph{train\_supervised} from the \emph{hmm.py} file imple
 Run this function given the simple dataset above and look at the estimated probabilities. Are they correct? You can also check the variables ending in \emph{\_counts} instead of \emph{\_probs} to see the raw counts (for example, typing \emph{hmm.initial\_counts} will show you the raw counts of initial states). How are the counts related to the probabilities?
 
 \begin{python}
->>> import lxmls.sequences.hmm as hmmc
->>> hmm = hmmc.HMM(simple.x_dict, simple.y_dict)
->>> hmm.train_supervised(simple.train)
->>> print "Initial Probabilities:", hmm.initial_probs
+import lxmls.sequences.hmm as hmmc
+hmm = hmmc.HMM(simple.x_dict, simple.y_dict)
+hmm.train_supervised(simple.train)
+print "Initial Probabilities:", hmm.initial_probs
+
 [ 0.66666667  0.33333333]
->>> print "Transition Probabilities:", hmm.transition_probs
+
+print "Transition Probabilities:", hmm.transition_probs
+
 [[ 0.5    0.   ]
  [ 0.5    0.625]]
->>> print "Final Probabilities:", hmm.final_probs
+
+print "Final Probabilities:", hmm.final_probs
+
 [ 0.     0.375]
->>> print "Emission Probabilities", hmm.emission_probs
+
+print "Emission Probabilities", hmm.emission_probs
+
 [[ 0.75   0.25 ]
  [ 0.25   0.375]
  [ 0.     0.375]

--- a/pages/sequences/pos-induction.tex
+++ b/pages/sequences/pos-induction.tex
@@ -18,11 +18,11 @@ Note, however that nothing is said about the identity of each cluster. The model
 \begin{exercise}
 Run 20 epochs of the EM algorithm for part of speech induction:
 \begin{python}
->>> hmm.train_EM(train_seq, 0.1, 20, evaluate=True)
->>> viterbi_pred_test = hmm.viterbi_decode_corpus(test_seq)
->>> posterior_pred_test = hmm.posterior_decode_corpus(test_seq)
->>> eval_viterbi_test =   hmm.evaluate_corpus(test_seq, viterbi_pred_test)
->>> eval_posterior_test = hmm.evaluate_corpus(test_seq, posterior_pred_test)
+hmm.train_EM(train_seq, 0.1, 20, evaluate=True)
+viterbi_pred_test = hmm.viterbi_decode_corpus(test_seq)
+posterior_pred_test = hmm.posterior_decode_corpus(test_seq)
+eval_viterbi_test =   hmm.evaluate_corpus(test_seq, viterbi_pred_test)
+eval_posterior_test = hmm.evaluate_corpus(test_seq, posterior_pred_test)
 
 Initial accuracy: 0.303638
 Iter: 1 Log Likelihood: -101824.763927
@@ -64,9 +64,9 @@ Iter: 18 Accuracy: 0.385409
 Iter: 19 Log Likelihood: -66442.608458
 Iter: 19 Accuracy: 0.385409
 
->>> confusion_matrix = cm.build_confusion_matrix(test_seq.seq_list, viterbi_pred_test, 
+confusion_matrix = cm.build_confusion_matrix(test_seq.seq_list, viterbi_pred_test, 
                                              len(corpus.tag_dict), hmm.get_num_states())
->>> cm.plot_confusion_bar_graph(confusion_matrix, corpus.tag_dict, 
+cm.plot_confusion_bar_graph(confusion_matrix, corpus.tag_dict, 
                             xrange(hmm.get_num_states()), 'Confusion matrix')
 \end{python}
 Note: your results may not be the same as in this example since we are using a random start, but the trend should be the same, 

--- a/pages/sequences/pos.tex
+++ b/pages/sequences/pos.tex
@@ -18,14 +18,14 @@ The first step is to load the corpus. We will start by loading
 1000 sentences for training and 1000 sentences both for development and
 testing. Then we train the HMM model by maximum likelihood estimation.
 \begin{python}
->>> import lxmls.readers.pos_corpus as pcc
->>> corpus = pcc.PostagCorpus()
->>> train_seq = corpus.read_sequence_list_conll("data/train-02-21.conll",max_sent_len=15,max_nr_sent=1000)
->>> test_seq = corpus.read_sequence_list_conll("data/test-23.conll",max_sent_len=15,max_nr_sent=1000)
->>> dev_seq = corpus.read_sequence_list_conll("data/dev-22.conll",max_sent_len=15,max_nr_sent=1000)
->>> hmm = hmmc.HMM(corpus.word_dict, corpus.tag_dict)
->>> hmm.train_supervised(train_seq)
->>> hmm.print_transition_matrix()
+import lxmls.readers.pos_corpus as pcc
+corpus = pcc.PostagCorpus()
+train_seq = corpus.read_sequence_list_conll("data/train-02-21.conll",max_sent_len=15,max_nr_sent=1000)
+test_seq = corpus.read_sequence_list_conll("data/test-23.conll",max_sent_len=15,max_nr_sent=1000)
+dev_seq = corpus.read_sequence_list_conll("data/dev-22.conll",max_sent_len=15,max_nr_sent=1000)
+hmm = hmmc.HMM(corpus.word_dict, corpus.tag_dict)
+hmm.train_supervised(train_seq)
+hmm.print_transition_matrix()
 \end{python}
 
 
@@ -50,17 +50,20 @@ state. Note the high probability of having Noun after Determinant or Adjective, 
 Test the model using both posterior decoding and Viterbi decoding on
 both the train and test set, using the methods in class HMM:
 \begin{python}
->>> viterbi_pred_train = hmm.viterbi_decode_corpus(train_seq)
->>> posterior_pred_train = hmm.posterior_decode_corpus(train_seq)
->>> eval_viterbi_train =   hmm.evaluate_corpus(train_seq, viterbi_pred_train)
->>> eval_posterior_train =  hmm.evaluate_corpus(train_seq, posterior_pred_train)
->>> print "Train Set Accuracy: Posterior Decode \%.3f, Viterbi Decode: \%.3f"\%(eval_posterior_train,eval_viterbi_train)
+viterbi_pred_train = hmm.viterbi_decode_corpus(train_seq)
+posterior_pred_train = hmm.posterior_decode_corpus(train_seq)
+eval_viterbi_train =   hmm.evaluate_corpus(train_seq, viterbi_pred_train)
+eval_posterior_train =  hmm.evaluate_corpus(train_seq, posterior_pred_train)
+print "Train Set Accuracy: Posterior Decode \%.3f, Viterbi Decode: \%.3f"\%(eval_posterior_train,eval_viterbi_train)
+
 Train Set Accuracy: Posterior Decode 0.985, Viterbi Decode: 0.985
->>> viterbi_pred_test = hmm.viterbi_decode_corpus(test_seq)
->>> posterior_pred_test = hmm.posterior_decode_corpus(test_seq)
->>> eval_viterbi_test =   hmm.evaluate_corpus(test_seq,viterbi_pred_test)
->>> eval_posterior_test = hmm.evaluate_corpus(test_seq,posterior_pred_test)
->>> print "Test Set Accuracy: Posterior Decode \%.3f, Viterbi Decode: \%.3f"\%(eval_posterior_test,eval_viterbi_test)
+
+viterbi_pred_test = hmm.viterbi_decode_corpus(test_seq)
+posterior_pred_test = hmm.posterior_decode_corpus(test_seq)
+eval_viterbi_test =   hmm.evaluate_corpus(test_seq,viterbi_pred_test)
+eval_posterior_test = hmm.evaluate_corpus(test_seq,posterior_pred_test)
+print "Test Set Accuracy: Posterior Decode \%.3f, Viterbi Decode: \%.3f"\%(eval_posterior_test,eval_viterbi_test)
+
 Test Set Accuracy: Posterior Decode 0.350, Viterbi Decode: 0.509
 \end{python}
 What do you observe? Remake the previous exercise but now train the HMM
@@ -70,7 +73,8 @@ train and development set. (Use function
 
 
 \begin{python}
->>> best_smoothing = hmm.pick_best_smoothing(train_seq, dev_seq, [10,1,0.1,0])
+best_smoothing = hmm.pick_best_smoothing(train_seq, dev_seq, [10,1,0.1,0])
+
 Smoothing 10.000000 --  Train Set Accuracy: Posterior Decode 0.731, Viterbi Decode: 0.691
 Smoothing 10.000000 -- Test Set Accuracy: Posterior Decode 0.712, Viterbi Decode: 0.675
 Smoothing 1.000000 --  Train Set Accuracy: Posterior Decode 0.887, Viterbi Decode: 0.865
@@ -79,12 +83,14 @@ Smoothing 0.100000 --  Train Set Accuracy: Posterior Decode 0.968, Viterbi Decod
 Smoothing 0.100000 -- Test Set Accuracy: Posterior Decode 0.851, Viterbi Decode: 0.842
 Smoothing 0.000000 --  Train Set Accuracy: Posterior Decode 0.985, Viterbi Decode: 0.985
 Smoothing 0.000000 -- Test Set Accuracy: Posterior Decode 0.370, Viterbi Decode: 0.526
->>> hmm.train_supervised(train_seq, smoothing=best_smoothing)
->>> viterbi_pred_test = hmm.viterbi_decode_corpus(test_seq)
->>> posterior_pred_test = hmm.posterior_decode_corpus(test_seq)
->>> eval_viterbi_test =   hmm.evaluate_corpus(test_seq, viterbi_pred_test)
->>> eval_posterior_test = hmm.evaluate_corpus(test_seq, posterior_pred_test)
->>> print "Best Smoothing \%f --  Test Set Accuracy: Posterior Decode \%.3f, Viterbi Decode: \%.3f"%(best_smoothing,eval_posterior_test,eval_viterbi_test)
+
+hmm.train_supervised(train_seq, smoothing=best_smoothing)
+viterbi_pred_test = hmm.viterbi_decode_corpus(test_seq)
+posterior_pred_test = hmm.posterior_decode_corpus(test_seq)
+eval_viterbi_test =   hmm.evaluate_corpus(test_seq, viterbi_pred_test)
+eval_posterior_test = hmm.evaluate_corpus(test_seq, posterior_pred_test)
+print "Best Smoothing \%f --  Test Set Accuracy: Posterior Decode \%.3f, Viterbi Decode: \%.3f"%(best_smoothing,eval_posterior_test,eval_viterbi_test)
+
 Best Smoothing 0.100000 --  Test Set Accuracy: Posterior Decode 0.837, Viterbi Decode: 0.827
 \end{python}
 
@@ -94,11 +100,11 @@ from. You can start by visualizing the confusion matrix (true tags vs
 predicted tags). You should get something like what is shown in Figure~\ref{fig:cmuns}.
 
 \begin{python}
->>> import lxmls.sequences.confusion_matrix as cm
->>> import matplotlib.pyplot as plt
->>> confusion_matrix = cm.build_confusion_matrix(test_seq.seq_list, viterbi_pred_test, len(corpus.tag_dict), hmm.get_num_states())
->>> cm.plot_confusion_bar_graph(confusion_matrix, corpus.tag_dict, xrange(hmm.get_num_states()), 'Confusion matrix')
->>> plt.show()
+import lxmls.sequences.confusion_matrix as cm
+import matplotlib.pyplot as plt
+confusion_matrix = cm.build_confusion_matrix(test_seq.seq_list, viterbi_pred_test, len(corpus.tag_dict), hmm.get_num_states())
+cm.plot_confusion_bar_graph(confusion_matrix, corpus.tag_dict, xrange(hmm.get_num_states()), 'Confusion matrix')
+plt.show()
 \end{python}
 
 \begin{figure}[h!]


### PR DESCRIPTION
Day 2 is the only part of the guide that adds the python prompt ('>>>') to the environments. I removed all of them to be consistent with the rest of guide. I also added blank lines between the actual outputs of print statements.