### PR TITLE
tiny naming changes

### DIFF
--- a/pages/sequences/em.tex
+++ b/pages/sequences/em.tex
@@ -26,7 +26,7 @@ that
 represent the number of times that each hidden variable is
 expected to be used with the current parameters setting. These expected sufficient
 statistics will then be used during learning as ``fake'' observations of
-the hidden variables. Using the node and edge posterior distributions
+the hidden variables. Using the state and transition posterior distributions
 described in Equations \ref{eq::nodePosterior} and \ref{eq::edgePosterior},
 the expected sufficient statistics can 
 be computed by the following formulas:

--- a/pages/sequences/ml.tex
+++ b/pages/sequences/ml.tex
@@ -99,7 +99,7 @@ of each count table we should observe the following:
 %  N-1 edges for each sentence, and the last edge is being accounted by
 %  the final transitions. So this leaves us with N-2 edges per sentence,
 %  where N is the number of tokens in that sentence.
-\item \textbf{Observation \ Counts\!:} -- Should sum to the number of tokens: $\sum_{j=1}^J\sum_{k=1}^K C_{\mathrm{emiss}}(w_j,c_k) = MN$.
+\item \textbf{Emission \ Counts\!:} -- Should sum to the number of tokens: $\sum_{j=1}^J\sum_{k=1}^K C_{\mathrm{emiss}}(w_j,c_k) = MN$.
 \end{itemize}
 
 Using the sufficient statistics (counts) the parameter estimates are: 


### PR DESCRIPTION
Some tiny naming changes on Day 2, for consistence:

* Section 2.3 (MLE): "Observation Counts" -> "Emission Counts"
* Section 2.7.1 (EM): "node and edge posterior" -> "state and transition posterior"