### PR TITLE
error in probabilities

### DIFF
--- a/pages/classification/classification.tex
+++ b/pages/classification/classification.tex
@@ -758,7 +758,7 @@ For example, if we throw a die and want to estimate the probability of its outco
 uniform distribution (each outcome having of probability a $1/6$). 
 Now suppose that we are only told that outcomes $\{1,2,3\}$ occurred $10$ times in total, and 
 $\{4,5,6\}$ occurred $30$ times in total, then the principle of maximum entropy would lead us to 
-estimate $P(1)=P(2)=P(3)=1/12$ and $P(1)=P(2)=P(3)=1/4$ (i.e., outcomes would be uniform 
+estimate $P(1)=P(2)=P(3)=1/12$ and $P(3)=P(4)=P(5)=1/4$ (i.e., outcomes would be uniform 
 within each of the two groups).\footnote{For an introduction of maximum entropy models, along with pointers to the literature, see 
 \url{http://www.cs.cmu.edu/~aberger/maxent.html}.}
 


### PR DESCRIPTION
error corected $P(1)=P(2)=P(3)=1/12$ and $P(1)=P(2)=P(3)=1/4$ is not correct.