### PR TITLE
Fixes in exercise 6.2

### DIFF
--- a/pages/deep_learning.tex
+++ b/pages/deep_learning.tex
@@ -321,10 +321,10 @@ e^N_k = \frac{\partial \log f_{k(m)}^N}{\partial z^{N}_{k}}
 \end{equation}
 
 \begin{exercise}
-Go to lxmls/deep\_learning/mlp.py:class MLP:def backprop\_grad() and complete the code of the MLP class with the Backpropagation recursion that we just saw. Once you are done. Try different network geometries by increasing the number of layers and layer sizes e.g.
+Go to lxmls/deep\_learning/mlp.py:class NumpyMLP:def grads() and complete the code of the NumpyMLP class with the Backpropagation recursion that we just saw. Once you are done. Try different network geometries by increasing the number of layers and layer sizes e.g.
 \begin{python}
 # Model parameters
-geometry = [I, 20, 2]
+geometry = [train_x.shape[0], 20, 2]
 actvfunc = ['sigmoid', 'softmax'] 
 # Instantiate model
 mlp      = dl.MLP(geometry, actvfunc) 

--- a/pages/deep_learning.tex
+++ b/pages/deep_learning.tex
@@ -329,7 +329,7 @@ actvfunc = ['sigmoid', 'softmax']
 # Instantiate model
 mlp      = dl.MLP(geometry, actvfunc) 
 \end{python}
-You can test the different models with the same sentiment analysis problem as in Exercise 7.1. 
+You can test the different models with the same sentiment analysis problem as in Exercise 6.1. 
 \begin{python}
 # Model parameters
 n_iter = 5


### PR DESCRIPTION
Just some small fixes on exercise 6.2.

I did have some trouble completing this exercise.
When comparing equations 6.31 and 6.32 with what is in lxmls-toolkit/lxmls/deep_learning/mlp.py, I can't figure out if the code is correct or not:
- when computing nabla_W and nabla_b: the code iterates through the geometry of the network, rather than the training set (like in equations 6.31/32)
- in line 138 it uses $\tilde z^n$ instead of $x^m$ -- although I believe this is a typo in the guide.

The results seem to be good, so the code is likely correct, but I can't see why that would be equivalent.
Also, in equation 6.32, the sum doesn't seem to depend on $m$.