### PR TITLE
replaced [a][b][c] by [a,b,c]

### DIFF
--- a/pages/parsing/parsing.tex
+++ b/pages/parsing/parsing.tex
@@ -453,12 +453,12 @@ the partition function and the posterior marginals.
 	\STATE Set $t := s + k$ \COMMENT{$t$ is end of span}
 	\STATE
 	\STATE \COMMENT{First, create incomplete spans.}
-	\STATE $\mathrm{incomplete}[s,t,\leftarrow] := \max_{s \le r < t} (\mathrm{complete}[s][r][\rightarrow] + \mathrm{complete}[r+1][t][\leftarrow] + s_{\boldsymbol{\theta}}(t,s)) $
-	\STATE $\mathrm{incomplete}[s,t,\rightarrow] := \max_{s \le r < t} (\mathrm{complete}[s][r][\rightarrow] + \mathrm{complete}[r+1][t][\leftarrow] + s_{\boldsymbol{\theta}}(s,t))$
+	\STATE $\mathrm{incomplete}[s,t,\leftarrow] := \max_{s \le r < t} (\mathrm{complete}[s,r,\rightarrow] + \mathrm{complete}[r+1,t,\leftarrow] + s_{\boldsymbol{\theta}}(t,s)) $
+	\STATE $\mathrm{incomplete}[s,t,\rightarrow] := \max_{s \le r < t} (\mathrm{complete}[s,r,\rightarrow] + \mathrm{complete}[r+1,t,\leftarrow] + s_{\boldsymbol{\theta}}(s,t))$
 	\STATE
 	\STATE \COMMENT{Then, create complete spans.}
-	\STATE $\mathrm{complete}[s,t,\leftarrow] := \max_{s \le r < t} (\mathrm{complete}[s][r][\leftarrow] + \mathrm{incomplete}[r][t][\leftarrow])$
-	\STATE $\mathrm{complete}[s,t,\rightarrow] := \max_{s \le r < t} (\mathrm{incomplete}[s][r+1][\rightarrow] + \mathrm{complete}[r+1][t][\rightarrow])$
+	\STATE $\mathrm{complete}[s,t,\leftarrow] := \max_{s \le r < t} (\mathrm{complete}[s,r,\leftarrow] + \mathrm{incomplete}[r,t,\leftarrow])$
+	\STATE $\mathrm{complete}[s,t,\rightarrow] := \max_{s \le r < t} (\mathrm{incomplete}[s,r+1,\rightarrow] + \mathrm{complete}[r+1,t,\rightarrow])$
 	\ENDFOR
 	\ENDFOR
 	\STATE


### PR DESCRIPTION
A student asked if complete[a,b,c] was the same as complete[a][b][c], in the pseudo-code, since there was mixed notation.