### PR TITLE
Corrected regex example in Syntax and Parsing.

### DIFF
--- a/pages/parsing/parsing.tex
+++ b/pages/parsing/parsing.tex
@@ -16,7 +16,7 @@ automata theory and formal languages.} %
 If $L$ is finite, a very simple automaton can be built which just memorizes the strings in $L$. 
 The next simplest case is that of \emph{regular languages}, which are recognizable by \emph{finite state machines}. 
 These are the languages that can be expressed by regular expressions. 
-An example (where $\mathcal{T} = \{a,b\}$) is the language $L = \{ab^naa^n \,|\,n \in \mathbb{N}\}$, which corresponds to 
+An example (where $\mathcal{T} = \{a,b\}$) is the language $L = \{ab^{n_1}aa^{n_2} \,|\,n_1,n_2 \in \mathbb{N}\}$, which corresponds to 
 the regular expression $ab*a+$. 
 \emph{Hidden Markov models} (studied in previous lectures) can be seen as a stochastic version of finite state machines.  
 


### PR DESCRIPTION
As far as I know the language `L = {ab^n aa^n | n ∈ N}` does not correspond to regex `ab* a+`, since there is no way to assure that the number of `a`'s and `b`'s are equal (that is `n`, as the definition states). Consequently, this is also not a language that could be expressed by regular expressions. I believe that what was meant is that these `n`'s are two different numbers, hence I propose the modification.