### PR TITLE
Non matching class names for Batch and Online Max Entropy Classifiers.

### DIFF
--- a/pages/classification/classification.tex
+++ b/pages/classification/classification.tex
@@ -923,7 +923,7 @@ as well as an implementation of the SGD algorithm in the class {\tt MaxEnt\_onli
 \begin{python}
 import lxmls.classifiers.max_ent_batch as mebc
 
-me_lbfgs = mebc.MaxEnt_batch()
+me_lbfgs = mebc.MaxEntbatch()
 me_lbfgs.regularizer = 1.0
 params_meb_sd = me_lbfgs.train(sd.train_X,sd.train_y)
 y_pred_train = me_lbfgs.test(sd.train_X,params_meb_sd)
@@ -951,7 +951,7 @@ Compare the objective values obtained during training with those obtained with L
 \begin{python}
 import lxmls.classifiers.max_ent_online as meoc
 
-me_sgd = meoc.MaxEnt_online()
+me_sgd = meoc.MaxEntonline()
 me_sgd.regularizer = 1.0
 params_meo_sc = me_sgd.train(scr.train_X,scr.train_y)
 y_pred_train = me_sgd.test(scr.train_X,params_meo_sc)


### PR DESCRIPTION
Max Entropy Batch and online classifiers classes are: MaxEntBatch and MaxEntOnline. In the guide (exercise 1.4), class names have an extra underscore (MaxEnt_Batch and MaxEnt_Online) which does not match the code.