### PR TITLE
Fixed parsing tree visualization link

### DIFF
--- a/pages/parsing/parsing.tex
+++ b/pages/parsing/parsing.tex
@@ -225,7 +225,7 @@ The following is an example of an annotated sentence in one of the most widely u
 
 \begin{exercise}\label{exer:treebank}
 This exercise will show you that real-world sentences can have complicated syntactic structures. 
-There is a parse tree visualizer in \url{http://www.ark.cs.cmu.edu/treeviz/}. 
+There is a parse tree visualizer in \url{http://brenocon.com/parseviz/}. 
 Go to your local {\tt data/treebanks} folder and open the file {\tt PTB\_excerpt.txt}. 
 Copy a few trees from the file, one at a time, and examine their parse trees in the visualizer.  
 \end{exercise}
@@ -646,7 +646,7 @@ The predicted trees are placed in the file {\tt data/deppars/english\_test.conll
 To get a sense of which errors are being made, you can 
 check the sentences that differ from the gold standard (see the data in {\tt data/deppars/english\_test.conll}) 
 and visualize those sentences, \emph{e.g.}, in 
-\url{http://www.ark.cs.cmu.edu/treeviz/}. 
+\url{http://brenocon.com/parseviz/}. 
 
 \item (Optional.) Implement Eisner's algorithm for \emph{projective} dependency parsing. 
 The pseudo-code is shown as Algorithm~\ref{alg:eisner}. Implement this algorithm as the function


### PR DESCRIPTION
Changed the link to visualize parsing trees, as the old one no longer exists (404 error).